### PR TITLE
Various setup.py 'fixes'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,16 @@
 # along with pTFTPd.  If not, see <http://www.gnu.org/licenses/>.
 
 from distutils.core import setup
+import sys
+
+try:
+    import netifaces
+except ImportError:
+    print """
+    'netifaces' is missing from your system, it's needed for pTFTPd to work.
+    If you are using Debian/Ubuntu, you need to install 'python-netifaces'
+    """
+    sys.exit(1)
 
 setup(name = "ptftpd",
     description = "pTFTPd, a pure-Python TFTP tool suite that works",


### PR DESCRIPTION
Since the introduction of netifaces, when I install ptftpd on a new machine, I always end up being notified through a crash that netifaces is not available.

With theses patch, the users is warned during the install, which seems nicer than during the first use of the program.
