### PR TITLE
changing datetime recording to time

### DIFF
--- a/ptftplib/state.py
+++ b/ptftplib/state.py
@@ -17,9 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with pTFTPd.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import datetime
 import errno
 import os
+import time
 
 from . import proto
 
@@ -74,7 +74,7 @@ class TFTPState(object):
             proto.TFTP_OPTION_WINDOWSIZE: proto.TFTP_DEFAULT_WINDOW_SIZE,
         }
 
-        self.last_seen = datetime.today()
+        self.last_seen = time.time()
 
         self.packetnum = None               # Current data packet number
         self.last_acked = 0                 # Packet number of the last acked
@@ -143,7 +143,7 @@ class TFTPState(object):
         Update the last seen value to restart the watchdog.
         """
 
-        self.last_seen = datetime.today()
+        self.last_seen = time.time()
 
     def set_opts(self, opts):
         """

--- a/ptftplib/tftpclient.py
+++ b/ptftplib/tftpclient.py
@@ -40,13 +40,13 @@ Note that this program currently does *not* support the timeout
 interval option from RFC2349.
 """
 
-from datetime import datetime
 import os
 import shutil
 import socket
 import stat
 import sys
 import tempfile
+import time
 
 from . import notify
 from . import proto
@@ -541,10 +541,10 @@ class TFTPClient(object):
 
         packet = proto.TFTPHelper.createRRQ(filepath, self.transfer_mode, opts)
 
-        transfer_start = datetime.today()
+        transfer_start = time.time()
         self.sock.send(packet, self.peer)
         self.handle()
-        transfer_time = datetime.today() - transfer_start
+        transfer_time = time.time() - transfer_start
 
         if self.error:
             error, errmsg = self.error
@@ -616,10 +616,10 @@ class TFTPClient(object):
 
         packet = proto.TFTPHelper.createWRQ(filepath, self.transfer_mode, opts)
 
-        transfer_start = datetime.today()
+        transfer_start = time.time()
         self.sock.send(packet, self.peer)
         self.handle()
-        transfer_time = datetime.today() - transfer_start
+        transfer_time = time.time() - transfer_start
 
         if self.error:
             error, errmsg = self.error
@@ -686,8 +686,7 @@ class TFTPClient(object):
             print('Window size must be a number!')
 
     def __get_speed(self, filesize, time):
-        return (filesize / 1024.0 /
-                (time.seconds + time.microseconds / 1000000.0))
+        return (filesize / 1024.0 / time)
 
 
 def usage():

--- a/ptftplib/tftpserver.py
+++ b/ptftplib/tftpserver.py
@@ -30,8 +30,6 @@ Note that this program currently does *not* support the timeout
 interval option from RFC2349.
 """
 
-from datetime import datetime
-from datetime import timedelta
 import errno
 import logging
 import netifaces
@@ -499,8 +497,8 @@ class TFTPServerGarbageCollector(threading.Thread):
             toremove = []
 
             for peer, peer_state in self.clients.items():
-                delta = datetime.today() - peer_state.last_seen
-                if delta > timedelta(seconds=state.STATE_TIMEOUT_SECS):
+                delta = time.time() - peer_state.last_seen
+                if delta > state.STATE_TIMEOUT_SECS:
                     if peer_state.state != state.STATE_ERROR:
                         l.debug("Peer %s:%d timed out." % peer,
                                 extra=peer_state.extra(notify.TRANSFER_FAILED))


### PR DESCRIPTION
Changed the somewhat redundant `datetime` wrappers to use the `time` object.

## Example:

**Old**:
```python
transfer_start = datetime.today()
# do something
transfer_time = datetime.today() - transfer_start
```

**New**:
```python
transfer_start = time.time()
# do something
transfer_time = time.time() - transfer_start
```

## Purpose
Fewer dependencies, also simplifies conversion:

```python
return (filesize / 1024.0 /
    (time.seconds + time.microseconds / 1000000.0))
```

changes to:

```python
return (filesize / 1024.0 / time)
```

**and**

```python
if delta > timedelta(seconds=state.STATE_TIMEOUT_SECS):
```

changes to

```python
if delta > state.STATE_TIMEOUT_SECS:
```

## Testing
Tested locally.