### PR TITLE
Allow tftp client to be imported as a library

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,22 @@ basic TFTP RFC1350 compliance mode, disabling all TFTP extensions for
 increased compatibility would you encouter any problem with your target
 system.
 
+Usage as a Library
+------------------
+
+pTFTPd TFTP client can also be imported and used within a Python script.
+
+```from ptftpd import tftpclient
+
+client = tftpclient.client('tftpsite.com')
+results = client.get(['-f', 'thefile.txt'])
+
+print(results[0] +  'kB')
+# prints 55234 kB
+
+print(results[1] + ' kB/s')
+# prints 100 kB/s```
+
 Installation
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ pTFTPd TFTP client can also be imported and used within a Python script.
 
 ```from ptftpd import tftpclient
 
-client = tftpclient.client('tftpsite.com')
+client = tftpclient.client(host='tftpsite.com', exts={'windowsize': 4})
 results = client.get(['-f', 'thefile.txt'])
 
 print(results[0] +  'kB')

--- a/ptftplib/tftpclient.py
+++ b/ptftplib/tftpclient.py
@@ -565,13 +565,13 @@ class TFTPClient(object):
                   .format(filename))
             return False
 
+        transfer_speed = self.__get_speed(self.PTFTP_STATE.filesize, transfer_time)
+
         print('Transfer complete, {} bytes ({:.2f} kB/s)'
-              .format(self.PTFTP_STATE.filesize,
-                      self.__get_speed(self.PTFTP_STATE.filesize,
-                                       transfer_time)))
+              .format(self.PTFTP_STATE.filesize, transfer_speed))
         self.PTFTP_STATE.file.close()
         os.remove(self.PTFTP_STATE.file.name)
-        return True
+        return (self.PTFTP_STATE.filesize, transfer_speed)
 
     def put(self, args):
         """
@@ -627,11 +627,11 @@ class TFTPClient(object):
                 print('Error: {}'.format(errmsg))
             return False
 
+        transfer_speed = self.__get_speed(self.PTFTP_STATE.filesize, transfer_time)
+
         print('Transfer complete, {} bytes ({:.2f} kB/s)'
-              .format(self.PTFTP_STATE.filesize,
-                      self.__get_speed(self.PTFTP_STATE.filesize,
-                                       transfer_time)))
-        return True
+              .format(self.PTFTP_STATE.filesize, transfer_speed))
+        return (self.PTFTP_STATE.filesize, transfer_speed)
 
     def mode(self, args):
         if len(args) > 1:
@@ -709,6 +709,11 @@ def usage():
     print('                         This will discard other TFTP option values.')
     print()
 
+def client(host=_PTFTP_DEFAULT_HOST, port=_PTFTP_DEFAULT_PORT, 
+           mode=_PTFTP_DEFAULT_MODE, exts={}, rfc1350=False):
+    client = TFTPClient((host, port), exts, mode, rfc1350)
+    client.connect()
+    return client
 
 def main():
     # TODO: convert to optparse


### PR DESCRIPTION
# Client Usable as a Library

Allows the ptftpd client tool to be imported as a library and integrated into other Python libraries.

## Usage

```python
from ptftpd import tftpclient

client = tftpclient.client(host='tftpsite.com', exts={'windowsize': 4})

results = client.get(['-f', 'thefile.txt'])
### or
results = client.put(['thefile.txt'])

print(results[0] +  'kB')
# prints 55234 kB

print(results[1] + ' kB/s')
# prints 100 kB/s
```