### PR TITLE
Identify PXE clients by the vendor class identifier (option 60) instead of checking for existence of parameter request list (option 55)

### DIFF
--- a/ptftplib/dhcpserver.py
+++ b/ptftplib/dhcpserver.py
@@ -62,9 +62,8 @@ DHCP_OPTION_REQUESTED_IP = 50         # Requested IP address
 DHCP_OPTION_LEASE_TIME = 51           # Lease time for the IP address
 DHCP_OPTION_OP = 53                   # The DHCP operation (see above)
 DHCP_OPTION_SERVER_ID = 54            # Server Identifier (IP address)
-DHCP_OPTION_PXE_REQ = 55              # The most basic PXE option. We
-                                      # only use this to identify PXE
-                                      # requests.
+DHCP_OPTION_VENDOR_CLASS_ID = 60      # The vendor class identifier, used
+                                      # to identify PXE clients
 DHCP_OPTION_CLIENT_UUID = 61          # The client machine UUID
 DHCP_OPTION_PXE_VENDOR = 43           # PXE vendor extensions
 DHCP_OPTION_CLIENT_UUID2 = 97         # The client machine UUID
@@ -215,7 +214,7 @@ class DhcpPacket(object):
                   len(value[1:]) == DHCP_CLIENT_UUID_LENGTH):
                 # First byte of the UUID is \0
                 self.uuid = _unpack_uuid(value[1:])
-            elif option == DHCP_OPTION_PXE_REQ:
+            elif option == DHCP_OPTION_VENDOR_CLASS_ID and value.startswith('PXEClient'):
                 self.is_pxe_request = True
             elif option == DHCP_OPTION_REQUESTED_IP:
                 self.requested_ip = _unpack_ip(value)

--- a/ptftplib/pxeserver.py
+++ b/ptftplib/pxeserver.py
@@ -42,10 +42,11 @@ l = notify.getLogger('pxed')
 
 
 class DHCPThread(threading.Thread):
-    def __init__(self, iface, bootfile, router):
+    def __init__(self, iface, bootfile, router, answer_all_requests):
         threading.Thread.__init__(self)
         self.setDaemon(True)
-        self.server = dhcpserver.DHCPServer(iface, bootfile, router=router)
+        self.server = dhcpserver.DHCPServer(iface, bootfile, router=router,
+                                            answer_all_requests=answer_all_requests)
 
     def run(self):
         self.server.serve_forever()
@@ -63,6 +64,9 @@ def main():
     parser.add_option("-g", "--gateway", dest="router", default=None,
                       help="The IP address of the default gateway "
                       "(by default, the IP of the PXE server)")
+    parser.add_option("-a", "--answer-all-dhcp-requests", dest="answer_all_requests",
+                      help="Enables DHCP response to all clients, "
+                           "default is PXE clients only", action="store_true", default=False)
     parser.add_option("-v", "--verbose", dest="loglevel", action="store_const",
                       const=logging.INFO, help="Output information messages",
                       default=logging.WARNING)
@@ -88,7 +92,7 @@ def main():
                                 fmt='%(levelname)s(%(name)s): %(message)s')
 
     try:
-        dhcp = DHCPThread(iface, bootfile, options.router)
+        dhcp = DHCPThread(iface, bootfile, options.router, options.answer_all_requests)
         tftp = tftpserver.TFTPServer(iface, root,
                                      strict_rfc1350=options.strict_rfc1350)
     except tftpserver.TFTPServerConfigurationError as e:


### PR DESCRIPTION
Fix for https://github.com/mpetazzoni/ptftpd/issues/16