### PR TITLE
cannot stat /proc/sys/net/inet/udp/maxdgram

### DIFF
--- a/ptftplib/tftpserver.py
+++ b/ptftplib/tftpserver.py
@@ -70,7 +70,10 @@ def get_ip_config_for_iface(iface):
 
 def get_max_udp_datagram_size():
     """Retrieve the maximum UDP datagram size allowed by the system."""
-    val = subprocess.check_output(['sysctl', '-n', 'net.inet.udp.maxdgram'])
+    try:
+        val = subprocess.check_output(['sysctl', '-n', 'net.inet.udp.maxdgram'])
+    except subprocess.CalledProcessError:
+        val = 1300
     return int(val)
 
 


### PR DESCRIPTION
Hotfix #32

Use safe value on modern linux or if sysctl not applicable.