### PR TITLE
Drop netifaces

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-netifaces

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,6 @@ with open('ptftplib/version.py') as f:
 with open('README.rst') as readme:
     long_description = readme.read()
 
-with open('requirements.txt') as f:
-    requirements = [line.strip() for line in f.readlines()]
-
 setup(
     name=name,  # noqa
     version=version,  # noqa
@@ -38,7 +35,7 @@ setup(
     license='GNU General Public License v2',
     long_description=long_description,
     zip_safe=True,
-    install_requires=requirements,
+    install_requires=[],
     packages=find_packages(),
     entry_points={
         'console_scripts':


### PR DESCRIPTION
[netifaces](https://github.com/al45tair/netifaces) is unmaintained. There are no prebuilt wheels for Python >3.9: netifaces
The dependency isn't actually needed at all: This PR removes it while keeping functionality as-is.

Tested manually:

```py
Python 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.31.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import errno
   ...: import fcntl
   ...: import logging
   ...: import os
   ...: import socket
   ...: import stat
   ...: import struct
   ...: import subprocess
   ...: import sys
   ...: import threading
   ...: import time

In [2]: class TFTPServerConfigurationError(Exception):
   ...:     """The configuration of the pTFTPd is incorrect."""
   ...:     pass
   ...: 

In [3]: def get_ip_config_for_iface(iface):
   ...:     """Retrieve and return the IP address/netmask of the given interface.
   ...: 
   ...:     Constants from https://github.com/torvalds/linux/blob/v6.8/include/uapi/linux/sockios.h#L62
   ...:     """
   ...:     SIOCGIFADDR = 0x8915
   ...:     SIOCGIFNETMASK = 0x891B
   ...:     iface_b = struct.pack("256s", iface.encode()[:15])
   ...:     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
   ...:     try:
   ...:         ip = socket.inet_ntoa(fcntl.ioctl(s, SIOCGIFADDR, iface_b)[20:24])
   ...:         nm = socket.inet_ntoa(fcntl.ioctl(s, SIOCGIFNETMASK, iface_b)[20:24])
   ...:     except OSError as exc:
   ...:         if exc.errno != errno.ENODEV:
   ...:             raise
   ...:         raise TFTPServerConfigurationError(
   ...:                 'Unknown network interface {}'.format(iface)) from exc
   ...:     return ip, nm
   ...: 

In [4]: get_ip_config_for_iface("lo")
Out[4]: ('127.0.0.1', '255.0.0.0')

In [5]: get_ip_config_for_iface("enp84s0")
Out[5]: ('192.168.1.118', '255.255.255.0')

In [6]: get_ip_config_for_iface("invalid")
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
<ipython-input-3-4770cfe43a82> in get_ip_config_for_iface(iface)
     10     try:
---> 11         ip = socket.inet_ntoa(fcntl.ioctl(s, SIOCGIFADDR, iface_b)[20:24])
     12         nm = socket.inet_ntoa(fcntl.ioctl(s, SIOCGIFNETMASK, iface_b)[20:24])

OSError: [Errno 19] No such device

The above exception was the direct cause of the following exception:

TFTPServerConfigurationError              Traceback (most recent call last)
<ipython-input-6-c8f3230e2872> in <module>
----> 1 get_ip_config_for_iface("invalid")

<ipython-input-3-4770cfe43a82> in get_ip_config_for_iface(iface)
     14         if exc.errno != errno.ENODEV:
     15             raise
---> 16         raise TFTPServerConfigurationError(
     17                 'Unknown network interface {}'.format(iface)) from exc
     18     return ip, nm

TFTPServerConfigurationError: Unknown network interface invalid

```